### PR TITLE
Fix name of child logger with empty parent logger

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -168,7 +168,14 @@ func (l *Loggerus) Flush() {
 
 // GetChild returns a child logger, if underlying logger supports hierarchal logging
 func (l *Loggerus) GetChild(name string) logger.Logger {
-	childLogger, _ := NewLoggerus(l.name+"."+name,
+	var childLoggerName string
+	if len(l.name) > 0 {
+		childLoggerName = l.name + "." + name
+	} else {
+		childLoggerName = name
+	}
+
+	childLogger, _ := NewLoggerus(childLoggerName,
 		l.logrus.Level,
 		l.logrus.Out,
 		l.logrus.Formatter)


### PR DESCRIPTION
This is ugly:
```
15-11-21 00:04:03.827 (I) No patch dir provided, not looking for objects to patch :: patchDirPath="" || who=".patch" || component="data-node-image"
```
Notice the `who`
This is the result of an empty string for a parent logger name, and a subsequent `GetChild` logger with the name `patch`
This should just be `who="patch"`